### PR TITLE
feat: add user blocking and refactor relationship logic

### DIFF
--- a/src/main/java/fr/utc/miage/sporttrack/controller/FriendshipController.java
+++ b/src/main/java/fr/utc/miage/sporttrack/controller/FriendshipController.java
@@ -1,6 +1,5 @@
 package fr.utc.miage.sporttrack.controller;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/fr/utc/miage/sporttrack/controller/FriendshipController.java
+++ b/src/main/java/fr/utc/miage/sporttrack/controller/FriendshipController.java
@@ -1,6 +1,9 @@
 package fr.utc.miage.sporttrack.controller;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
@@ -14,12 +17,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import fr.utc.miage.sporttrack.entity.enumeration.FriendshipStatus;
+import fr.utc.miage.sporttrack.dto.RelationshipStatusDTO;
 import fr.utc.miage.sporttrack.entity.user.Athlete;
 import fr.utc.miage.sporttrack.entity.user.communication.Friendship;
 import fr.utc.miage.sporttrack.repository.user.AthleteRepository;
 import fr.utc.miage.sporttrack.repository.user.communication.FriendshipRepository;
-import fr.utc.miage.sporttrack.service.user.AthleteService;
 import fr.utc.miage.sporttrack.service.user.communication.FriendshipService;
 import jakarta.servlet.http.HttpSession;
 
@@ -27,7 +29,7 @@ import jakarta.servlet.http.HttpSession;
  * Controller for friendship-related pages and actions.
  * <p>
  * Manages friend listing, sending/accepting/rejecting friend requests,
- * removing friends, and viewing friend profiles.
+ * removing friends, blocking/unblocking users, and viewing friend profiles.
  */
 @Controller
 public class FriendshipController {
@@ -35,17 +37,15 @@ public class FriendshipController {
     private final FriendshipService friendshipService;
     private final FriendshipRepository friendshipRepository;
     private final AthleteRepository athleteRepository;
-    private final AthleteService athleteService;
 
-    public FriendshipController(FriendshipService friendshipService, FriendshipRepository friendshipRepository, AthleteRepository athleteRepository, AthleteService athleteService) {
+    public FriendshipController(FriendshipService friendshipService, FriendshipRepository friendshipRepository, AthleteRepository athleteRepository) {
         this.friendshipService = friendshipService;
         this.friendshipRepository = friendshipRepository;
         this.athleteRepository = athleteRepository;
-        this.athleteService = athleteService;
     }
 
     /**
-     * Shows the main friendship management page with 4 tabs.
+     * Shows the main friendship management page with 5 tabs.
      * Loads all data at once for all tabs.
      *
      * @param session the current HTTP session
@@ -65,22 +65,26 @@ public class FriendshipController {
         List<Athlete> friends = friendshipService.getFriendsOfAthlete(athlete.getId());
         List<Friendship> requests = friendshipService.getPendingRequestsForAthlete(athlete.getId());
         List<Friendship> sentRequests = friendshipService.getSentPendingRequests(athlete.getId());
+        List<Friendship> blockedUsers = friendshipService.getBlockedUsers(athlete.getId());
 
-        // Search athletes for "Add friend" tab
-        List<Athlete> athletes;
+        // Search athletes for "Add friend" tab — using the filtered search
+        List<Athlete> athletes = friendshipService.searchVisibleAthletes(athlete.getId(), query);
         if (query != null && !query.isEmpty()) {
-            athletes = athleteService.searchAthletesByName(query);
             model.addAttribute("query", query);
-        } else {
-            athletes = athleteService.getAllAthletes();
         }
-        // Remove current user from search results
-        athletes.removeIf(a -> a.getId().equals(athlete.getId()));
+
+        // Compute relationship status for each athlete in search results
+        Map<Integer, RelationshipStatusDTO> relationshipStatuses = new HashMap<>();
+        for (Athlete a : athletes) {
+            relationshipStatuses.put(a.getId(), friendshipService.getRelationshipStatus(athlete.getId(), a.getId()));
+        }
 
         model.addAttribute("friends", friends);
         model.addAttribute("requests", requests);
         model.addAttribute("sentRequests", sentRequests);
         model.addAttribute("athletes", athletes);
+        model.addAttribute("blockedUsers", blockedUsers);
+        model.addAttribute("relationshipStatuses", relationshipStatuses);
         model.addAttribute("activeTab", tab != null ? tab : "friends");
         model.addAttribute("currentAthlete", athlete);
 
@@ -109,28 +113,14 @@ public class FriendshipController {
         }
         Athlete target = targetOpt.get();
 
-        // Determine relationship status
-        String relationshipStatus;
+        // Compute relationship status using the service
+        RelationshipStatusDTO relationshipStatus = friendshipService.getRelationshipStatus(athlete.getId(), target.getId());
+
+        // Also get the raw friendship record for display
         Optional<Friendship> friendshipOpt = friendshipRepository.findBetweenAthletes(athlete, target);
 
-        if (athlete.getId().equals(target.getId())) {
-            relationshipStatus = "SELF";
-        } else if (friendshipOpt.isEmpty()) {
-            relationshipStatus = "NONE";
-        } else {
-            Friendship friendship = friendshipOpt.get();
-            if (friendship.getStatus() == FriendshipStatus.ACCEPTED) {
-                relationshipStatus = "ACCEPTED";
-            } else if (friendship.getStatus() == FriendshipStatus.PENDING) {
-                relationshipStatus = "PENDING";
-            } else {
-                // REJECTED or other → treat as NONE
-                relationshipStatus = "NONE";
-            }
-        }
-
         model.addAttribute("profileAthlete", target);
-        model.addAttribute("relationshipStatus", relationshipStatus);
+        model.addAttribute("relationshipStatus", relationshipStatus.name());
         model.addAttribute("friendship", friendshipOpt.orElse(null));
         model.addAttribute("currentAthlete", athlete);
 
@@ -139,11 +129,6 @@ public class FriendshipController {
 
     /**
      * Sends a friend request to another athlete.
-     *
-     * @param session            the current HTTP session
-     * @param recipientId        the ID of the athlete to send the request to
-     * @param redirectAttributes used to pass flash messages
-     * @return a redirect to the friends page
      */
     @PostMapping("/friends/send")
     public String sendFriendRequest(HttpSession session, @RequestParam("recipientId") Integer recipientId, RedirectAttributes redirectAttributes) {
@@ -164,11 +149,6 @@ public class FriendshipController {
 
     /**
      * Accepts a pending friend request.
-     *
-     * @param id                 the friendship ID
-     * @param session            the current HTTP session
-     * @param redirectAttributes used to pass flash messages
-     * @return a redirect to the friends page
      */
     @PostMapping("/friends/accept/{id}")
     public String acceptFriendRequest(@PathVariable("id") Integer id, HttpSession session, RedirectAttributes redirectAttributes) {
@@ -189,11 +169,6 @@ public class FriendshipController {
 
     /**
      * Rejects a pending friend request.
-     *
-     * @param id                 the friendship ID
-     * @param session            the current HTTP session
-     * @param redirectAttributes used to pass flash messages
-     * @return a redirect to the friends page
      */
     @PostMapping("/friends/reject/{id}")
     public String rejectFriendRequest(@PathVariable("id") Integer id, HttpSession session, RedirectAttributes redirectAttributes) {
@@ -214,11 +189,6 @@ public class FriendshipController {
 
     /**
      * Removes an established friendship.
-     *
-     * @param id                 the friend's athlete ID
-     * @param session            the current HTTP session
-     * @param redirectAttributes used to pass flash messages
-     * @return a redirect to the friends page
      */
     @PostMapping("/friends/remove/{id}")
     public String removeFriend(@PathVariable("id") Integer id, HttpSession session, RedirectAttributes redirectAttributes) {
@@ -235,6 +205,47 @@ public class FriendshipController {
         }
 
         return "redirect:/friends?tab=friends";
+    }
+
+    /**
+     * Blocks another user.
+     */
+    @PostMapping("/friends/block/{id}")
+    public String blockUser(@PathVariable("id") Integer id, HttpSession session, RedirectAttributes redirectAttributes) {
+        Athlete athlete = getAuthenticatedAthlete(session);
+        if (athlete == null) {
+            return "redirect:/login";
+        }
+
+        try {
+            friendshipService.blockUser(athlete.getId(), id);
+            redirectAttributes.addFlashAttribute("success", "Utilisateur bloqué avec succès.");
+        } catch (Exception e) {
+            redirectAttributes.addFlashAttribute("error", e.getMessage());
+        }
+
+        // Redirect back to the referring page
+        return "redirect:/friends?tab=blocked";
+    }
+
+    /**
+     * Unblocks a previously blocked user.
+     */
+    @PostMapping("/friends/unblock/{id}")
+    public String unblockUser(@PathVariable("id") Integer id, HttpSession session, RedirectAttributes redirectAttributes) {
+        Athlete athlete = getAuthenticatedAthlete(session);
+        if (athlete == null) {
+            return "redirect:/login";
+        }
+
+        try {
+            friendshipService.unblockUser(athlete.getId(), id);
+            redirectAttributes.addFlashAttribute("success", "Utilisateur débloqué avec succès.");
+        } catch (Exception e) {
+            redirectAttributes.addFlashAttribute("error", e.getMessage());
+        }
+
+        return "redirect:/friends?tab=blocked";
     }
 
     /**

--- a/src/main/java/fr/utc/miage/sporttrack/dto/RelationshipStatusDTO.java
+++ b/src/main/java/fr/utc/miage/sporttrack/dto/RelationshipStatusDTO.java
@@ -1,0 +1,36 @@
+package fr.utc.miage.sporttrack.dto;
+
+/**
+ * View-layer enum representing the relationship status between two athletes.
+ * Used by the frontend (Thymeleaf templates) to determine which buttons to display.
+ * This is computed from the underlying Friendship entity and FriendshipStatus.
+ */
+public enum RelationshipStatusDTO {
+
+    /** Viewing own profile */
+    SELF,
+
+    /** Already friends (FriendshipStatus.ACCEPTED) */
+    FRIENDS,
+
+    /** Current user sent a pending friend request (is the initiator) */
+    REQUEST_SENT,
+
+    /** Current user received a pending friend request (is the recipient) */
+    REQUEST_RECEIVED,
+
+    /** Friend request was rejected */
+    REJECTED,
+
+    /** Current user has blocked the target user */
+    BLOCKED_BY_ME,
+
+    /** Target user has blocked the current user */
+    BLOCKED_ME,
+
+    /** Both users have blocked each other */
+    MUTUALLY_BLOCKED,
+
+    /** No relationship exists — can send a friend request */
+    NONE
+}

--- a/src/main/java/fr/utc/miage/sporttrack/entity/enumeration/FriendshipStatus.java
+++ b/src/main/java/fr/utc/miage/sporttrack/entity/enumeration/FriendshipStatus.java
@@ -4,6 +4,7 @@ public enum FriendshipStatus {
 
     PENDING,
     ACCEPTED,
-    REJECTED
+    REJECTED,
+    BLOCKED
 
 }

--- a/src/main/java/fr/utc/miage/sporttrack/entity/user/communication/Friendship.java
+++ b/src/main/java/fr/utc/miage/sporttrack/entity/user/communication/Friendship.java
@@ -49,6 +49,13 @@ public class Friendship {
         this.createdAt = LocalDateTime.now();
     }
 
+    public Friendship(Athlete initiator, Athlete recipient, FriendshipStatus status) {
+        this.initiator = initiator;
+        this.recipient = recipient;
+        this.status = status;
+        this.createdAt = LocalDateTime.now();
+    }
+
 
     public Integer getId() {
         return id;

--- a/src/main/java/fr/utc/miage/sporttrack/repository/user/communication/FriendshipRepository.java
+++ b/src/main/java/fr/utc/miage/sporttrack/repository/user/communication/FriendshipRepository.java
@@ -44,4 +44,27 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Integer>
             "f.status = :status")
     List<Friendship> findByAthleteAndStatus(@Param("athleteId") Integer athleteId,
                                             @Param("status") FriendshipStatus status);
+
+    /**
+     * Checks if blocker has blocked blocked (one-directional).
+     *
+     * @param blocker the athlete who initiated the block
+     * @param blocked the athlete who was blocked
+     * @return true if such a BLOCKED relationship exists
+     */
+    @Query("SELECT CASE WHEN COUNT(f) > 0 THEN true ELSE false END FROM Friendship f " +
+            "WHERE f.initiator = :blocker AND f.recipient = :blocked AND f.status = 'BLOCKED'")
+    boolean existsBlock(@Param("blocker") Athlete blocker, @Param("blocked") Athlete blocked);
+
+    /**
+     * Returns the IDs of all users who have blocked the given user.
+     */
+    @Query("SELECT f.initiator.id FROM Friendship f WHERE f.recipient.id = :userId AND f.status = 'BLOCKED'")
+    List<Integer> findBlockedByUserIds(@Param("userId") Integer userId);
+
+    /**
+     * Returns the IDs of all users that the given user has blocked.
+     */
+    @Query("SELECT f.recipient.id FROM Friendship f WHERE f.initiator.id = :userId AND f.status = 'BLOCKED'")
+    List<Integer> findBlockedUserIds(@Param("userId") Integer userId);
 }

--- a/src/main/java/fr/utc/miage/sporttrack/service/user/communication/FriendshipService.java
+++ b/src/main/java/fr/utc/miage/sporttrack/service/user/communication/FriendshipService.java
@@ -1,5 +1,6 @@
 package fr.utc.miage.sporttrack.service.user.communication;
 
+import fr.utc.miage.sporttrack.dto.RelationshipStatusDTO;
 import fr.utc.miage.sporttrack.entity.enumeration.FriendshipStatus;
 import fr.utc.miage.sporttrack.entity.user.Athlete;
 import fr.utc.miage.sporttrack.entity.user.communication.Friendship;
@@ -10,7 +11,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 @Service
 public class FriendshipService {
@@ -26,8 +30,11 @@ public class FriendshipService {
         this.athleteRepository = athleteRepository;
     }
 
+    // ========================= Friend Request =========================
+
     /**
      * Sends a friend request from one user to another.
+     * Checks for block relationships before allowing the request.
      */
     @Transactional
     public void sendFriendRequest(Integer initiatorId, Integer recipientId) {
@@ -37,14 +44,23 @@ public class FriendshipService {
         }
 
         // Look up both athletes
-        Athlete initiator = athleteRepository.findById(initiatorId).orElseThrow(() -> new IllegalArgumentException("Initiator not found"));
-        Athlete recipient = athleteRepository.findById(recipientId).orElseThrow(() -> new IllegalArgumentException("Recipient not found"));
+        Athlete initiator = findAthleteOrThrow(initiatorId, "Initiator not found");
+        Athlete recipient = findAthleteOrThrow(recipientId, "Recipient not found");
+
+        // Check if initiator has blocked recipient
+        if (friendshipRepository.existsBlock(initiator, recipient)) {
+            throw new IllegalStateException("You have blocked this user. Unblock them first.");
+        }
+
+        // Check if recipient has blocked initiator
+        if (friendshipRepository.existsBlock(recipient, initiator)) {
+            throw new IllegalStateException("Cannot send friend request to this user.");
+        }
 
         // Check if a relationship already exists between the two athletes
-        friendshipRepository.findBetweenAthletes(initiator, recipient).ifPresentOrElse(existing -> handleExistingFriendship(existing, initiator, recipient), () ->
-                // No existing relationship → create a new one
-                friendshipRepository.save(new Friendship(initiator, recipient))
-
+        friendshipRepository.findBetweenAthletes(initiator, recipient).ifPresentOrElse(
+                existing -> handleExistingFriendship(existing, initiator, recipient),
+                () -> friendshipRepository.save(new Friendship(initiator, recipient))
         );
     }
 
@@ -63,29 +79,21 @@ public class FriendshipService {
                 existing.setCreatedAt(LocalDateTime.now());
                 friendshipRepository.save(existing);
             }
+            case BLOCKED -> throw new IllegalStateException("A block relationship exists between you and this user");
         }
     }
 
     /**
      * Accept a pending friend request.
-     * <ul>
-     *   <li>Only the recipient can accept</li>
-     *   <li>Only a PENDING request can be accepted</li>
-     * </ul>
-     *
-     * @param friendshipId  the ID of the friendship record
-     * @param currentUserId the ID of the current user (must be the recipient)
      */
     @Transactional
     public void acceptFriendRequest(Integer friendshipId, Integer currentUserId) {
         Friendship friendship = findFriendshipOrThrow(friendshipId);
 
-        // Only the recipient can accept
         if (!friendship.getRecipient().getId().equals(currentUserId)) {
             throw new IllegalArgumentException("Only the recipient can accept a friend request");
         }
 
-        // Only PENDING requests can be accepted
         if (friendship.getStatus() != FriendshipStatus.PENDING) {
             throw new IllegalStateException("Only pending friend requests can be accepted");
         }
@@ -101,12 +109,10 @@ public class FriendshipService {
     public void rejectFriendRequest(Integer friendshipId, Integer currentUserId) {
         Friendship friendship = findFriendshipOrThrow(friendshipId);
 
-        // Only the recipient can reject
         if (!friendship.getRecipient().getId().equals(currentUserId)) {
             throw new IllegalArgumentException("Only the recipient can reject a friend request");
         }
 
-        // Only PENDING requests can be rejected
         if (friendship.getStatus() != FriendshipStatus.PENDING) {
             throw new IllegalStateException("Only pending friend requests can be rejected");
         }
@@ -120,20 +126,106 @@ public class FriendshipService {
      */
     @Transactional
     public void removeFriend(Integer currentUserId, Integer otherUserId) {
-        // Look up both athletes
-        Athlete currentUser = athleteRepository.findById(currentUserId).orElseThrow(() -> new IllegalArgumentException("Current user not found"));
-        Athlete otherUser = athleteRepository.findById(otherUserId).orElseThrow(() -> new IllegalArgumentException("Other user not found"));
+        Athlete currentUser = findAthleteOrThrow(currentUserId, "Current user not found");
+        Athlete otherUser = findAthleteOrThrow(otherUserId, "Other user not found");
 
-        // Find the friendship between them
-        Friendship friendship = friendshipRepository.findBetweenAthletes(currentUser, otherUser).orElseThrow(() -> new IllegalArgumentException("Friendship does not exist"));
+        Friendship friendship = friendshipRepository.findBetweenAthletes(currentUser, otherUser)
+                .orElseThrow(() -> new IllegalArgumentException("Friendship does not exist"));
 
-        // Only ACCEPTED friendships can be removed
         if (friendship.getStatus() != FriendshipStatus.ACCEPTED) {
             throw new IllegalStateException("Only accepted friendships can be removed");
         }
 
         friendshipRepository.delete(friendship);
     }
+
+    // ========================= Block / Unblock =========================
+
+    /**
+     * Blocks a user. Handles all existing relationship states:
+     * - If already friends: removes friendship and blocks.
+     * - If pending request: cancels it and blocks.
+     * - If rejected: blocks.
+     * - If already blocked by blocker: throws exception.
+     * - If no relationship: creates a new BLOCKED record.
+     *
+     * @param blockerId the user performing the block
+     * @param blockedId the user being blocked
+     */
+    @Transactional
+    public void blockUser(Integer blockerId, Integer blockedId) {
+        if (blockerId.equals(blockedId)) {
+            throw new IllegalArgumentException("You cannot block yourself");
+        }
+
+        Athlete blocker = findAthleteOrThrow(blockerId, "Blocker not found");
+        Athlete blocked = findAthleteOrThrow(blockedId, "User to block not found");
+
+        Optional<Friendship> existingOpt = friendshipRepository.findBetweenAthletes(blocker, blocked);
+
+        if (existingOpt.isPresent()) {
+            Friendship existing = existingOpt.get();
+            switch (existing.getStatus()) {
+                case BLOCKED -> {
+                    if (existing.getInitiator().getId().equals(blockerId)) {
+                        throw new IllegalStateException("You have already blocked this user");
+                    } else {
+                        // The other user blocked us — but we still want to block them too.
+                        // Update the existing record: make blocker the initiator.
+                        existing.setInitiator(blocker);
+                        existing.setRecipient(blocked);
+                        existing.setStatus(FriendshipStatus.BLOCKED);
+                        existing.setCreatedAt(LocalDateTime.now());
+                        friendshipRepository.save(existing);
+                    }
+                }
+                case ACCEPTED, PENDING, REJECTED -> {
+                    // Any existing relationship → convert to BLOCKED
+                    existing.setInitiator(blocker);
+                    existing.setRecipient(blocked);
+                    existing.setStatus(FriendshipStatus.BLOCKED);
+                    existing.setCreatedAt(LocalDateTime.now());
+                    friendshipRepository.save(existing);
+                }
+            }
+        } else {
+            // No existing relationship → create a new BLOCKED record
+            friendshipRepository.save(new Friendship(blocker, blocked, FriendshipStatus.BLOCKED));
+        }
+    }
+
+    /**
+     * Unblocks a previously blocked user.
+     * Only the user who initiated the block can unblock.
+     *
+     * @param blockerId the user who performed the block
+     * @param blockedId the user to unblock
+     */
+    @Transactional
+    public void unblockUser(Integer blockerId, Integer blockedId) {
+        if (blockerId.equals(blockedId)) {
+            throw new IllegalArgumentException("Invalid operation");
+        }
+
+        Athlete blocker = findAthleteOrThrow(blockerId, "Blocker not found");
+        Athlete blocked = findAthleteOrThrow(blockedId, "Blocked user not found");
+
+        Friendship friendship = friendshipRepository.findBetweenAthletes(blocker, blocked)
+                .orElseThrow(() -> new IllegalArgumentException("No relationship exists between these users"));
+
+        if (friendship.getStatus() != FriendshipStatus.BLOCKED) {
+            throw new IllegalStateException("This user is not blocked");
+        }
+
+        if (!friendship.getInitiator().getId().equals(blockerId)) {
+            throw new IllegalStateException("You did not block this user, so you cannot unblock them");
+        }
+
+        // Remove the block record entirely
+        friendshipRepository.delete(friendship);
+    }
+
+    // ========================= Query Methods =========================
 
     /**
      * Returns a list of all accepted friends for a specific athlete.
@@ -156,8 +248,7 @@ public class FriendshipService {
      * Returns all pending friend requests waiting for the athlete to accept.
      */
     public List<Friendship> getPendingRequestsForAthlete(Integer athleteId) {
-        Athlete athlete = athleteRepository.findById(athleteId).orElseThrow(() -> new IllegalArgumentException("Athlete not found"));
-
+        Athlete athlete = findAthleteOrThrow(athleteId, "Athlete not found");
         return friendshipRepository.findByRecipientAndStatus(athlete, FriendshipStatus.PENDING);
     }
 
@@ -165,16 +256,135 @@ public class FriendshipService {
      * Returns all friend requests sent by the athlete that are still pending.
      */
     public List<Friendship> getSentPendingRequests(Integer athleteId) {
-        Athlete athlete = athleteRepository.findById(athleteId).orElseThrow(() -> new IllegalArgumentException("Athlete not found"));
-
+        Athlete athlete = findAthleteOrThrow(athleteId, "Athlete not found");
         return friendshipRepository.findByInitiatorAndStatus(athlete, FriendshipStatus.PENDING);
     }
 
+    /**
+     * Returns all users blocked by the given athlete.
+     */
+    public List<Friendship> getBlockedUsers(Integer athleteId) {
+        Athlete athlete = findAthleteOrThrow(athleteId, "Athlete not found");
+        return friendshipRepository.findByInitiatorAndStatus(athlete, FriendshipStatus.BLOCKED);
+    }
+
+    // ========================= Relationship Status =========================
+
+    /**
+     * Computes the relationship status from the perspective of viewerId looking at targetId.
+     * Returns a RelationshipStatusDTO that the frontend can use to determine button display.
+     *
+     * @param viewerId the current user
+     * @param targetId the user being viewed
+     * @return the computed relationship status
+     */
+    public RelationshipStatusDTO getRelationshipStatus(Integer viewerId, Integer targetId) {
+        if (viewerId.equals(targetId)) {
+            return RelationshipStatusDTO.SELF;
+        }
+
+        Athlete viewer = findAthleteOrThrow(viewerId, "Viewer not found");
+        Athlete target = findAthleteOrThrow(targetId, "Target not found");
+
+        boolean viewerBlockedTarget = friendshipRepository.existsBlock(viewer, target);
+        boolean targetBlockedViewer = friendshipRepository.existsBlock(target, viewer);
+
+        if (viewerBlockedTarget && targetBlockedViewer) {
+            return RelationshipStatusDTO.MUTUALLY_BLOCKED;
+        }
+        if (viewerBlockedTarget) {
+            return RelationshipStatusDTO.BLOCKED_BY_ME;
+        }
+        if (targetBlockedViewer) {
+            return RelationshipStatusDTO.BLOCKED_ME;
+        }
+
+        Optional<Friendship> friendshipOpt = friendshipRepository.findBetweenAthletes(viewer, target);
+        if (friendshipOpt.isEmpty()) {
+            return RelationshipStatusDTO.NONE;
+        }
+
+        Friendship friendship = friendshipOpt.get();
+        return switch (friendship.getStatus()) {
+            case ACCEPTED -> RelationshipStatusDTO.FRIENDS;
+            case PENDING -> {
+                if (friendship.getInitiator().getId().equals(viewerId)) {
+                    yield RelationshipStatusDTO.REQUEST_SENT;
+                } else {
+                    yield RelationshipStatusDTO.REQUEST_RECEIVED;
+                }
+            }
+            case REJECTED -> RelationshipStatusDTO.REJECTED;
+            case BLOCKED -> {
+                // This case should be handled above, but just in case
+                if (friendship.getInitiator().getId().equals(viewerId)) {
+                    yield RelationshipStatusDTO.BLOCKED_BY_ME;
+                } else {
+                    yield RelationshipStatusDTO.BLOCKED_ME;
+                }
+            }
+        };
+    }
+
+    // ========================= Search =========================
+
+    /**
+     * Searches for athletes visible to the current user.
+     * Filters out:
+     * - The current user themselves
+     * - Users the current user has blocked
+     * - Users who have blocked the current user
+     *
+     * @param currentUserId the ID of the user performing the search
+     * @param keyword       the search keyword (username)
+     * @return list of visible athletes matching the keyword
+     */
+    public List<Athlete> searchVisibleAthletes(Integer currentUserId, String keyword) {
+        // Get all athletes matching the keyword
+        List<Athlete> allAthletes;
+        if (keyword != null && !keyword.isEmpty()) {
+            allAthletes = athleteRepository.findByUsernameContainingIgnoreCase(keyword);
+        } else {
+            allAthletes = athleteRepository.findAll();
+        }
+
+        // Build the set of IDs to exclude
+        Set<Integer> excludedIds = new HashSet<>();
+        excludedIds.add(currentUserId); // exclude self
+
+        // Exclude users the current user has blocked
+        List<Integer> blockedByMe = friendshipRepository.findBlockedUserIds(currentUserId);
+        excludedIds.addAll(blockedByMe);
+
+        // Exclude users who have blocked the current user
+        List<Integer> blockedMe = friendshipRepository.findBlockedByUserIds(currentUserId);
+        excludedIds.addAll(blockedMe);
+
+        // Filter the results
+        List<Athlete> visibleAthletes = new ArrayList<>();
+        for (Athlete a : allAthletes) {
+            if (!excludedIds.contains(a.getId())) {
+                visibleAthletes.add(a);
+            }
+        }
+        return visibleAthletes;
+    }
+
+    // ========================= Helpers =========================
 
     /**
      * Finds a friendship by its ID or throws an error if not found.
      */
     private Friendship findFriendshipOrThrow(Integer friendshipId) {
-        return friendshipRepository.findById(friendshipId).orElseThrow(() -> new IllegalArgumentException("Friendship not found"));
+        return friendshipRepository.findById(friendshipId)
+                .orElseThrow(() -> new IllegalArgumentException("Friendship not found"));
+    }
+
+    /**
+     * Finds an athlete by ID or throws an error if not found.
+     */
+    private Athlete findAthleteOrThrow(Integer athleteId, String errorMessage) {
+        return athleteRepository.findById(athleteId)
+                .orElseThrow(() -> new IllegalArgumentException(errorMessage));
     }
 }

--- a/src/main/resources/templates/athlete/friend/friends.html
+++ b/src/main/resources/templates/athlete/friend/friends.html
@@ -78,6 +78,13 @@
                     <i class="bi bi-person-plus me-1"></i> Ajouter
                 </button>
             </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" id="blocked-tab" data-bs-toggle="tab" data-bs-target="#tab-blocked"
+                        type="button" role="tab" aria-controls="tab-blocked" aria-selected="false">
+                    <i class="bi bi-slash-circle me-1"></i> Liste noire
+                    <span class="badge bg-danger ms-1 tab-badge" th:text="${#lists.size(blockedUsers)}">0</span>
+                </button>
+            </li>
         </ul>
 
         <!-- Tab Content -->
@@ -267,12 +274,83 @@
                                         </span>
                                     </div>
                                 </div>
-                                <form th:action="@{/friends/send}" method="post">
-                                    <input type="hidden" name="recipientId" th:value="${a.id}"/>
-                                    <button type="submit" class="btn btn-outline-primary btn-sm">
-                                        <i class="bi bi-person-plus"></i> Envoyer une demande
-                                    </button>
-                                </form>
+
+                                <!-- Status-aware buttons -->
+                                <div th:with="rs=${relationshipStatuses.get(a.id)}">
+
+                                    <!-- NONE: can send request -->
+                                    <form th:if="${rs != null and rs.name() == 'NONE'}" th:action="@{/friends/send}" method="post">
+                                        <input type="hidden" name="recipientId" th:value="${a.id}"/>
+                                        <button type="submit" class="btn btn-outline-primary btn-sm">
+                                            <i class="bi bi-person-plus"></i> Envoyer une demande
+                                        </button>
+                                    </form>
+
+                                    <!-- REQUEST_SENT: pending, show disabled -->
+                                    <span th:if="${rs != null and rs.name() == 'REQUEST_SENT'}" class="badge bg-warning text-dark">
+                                        <i class="bi bi-hourglass-split"></i> Demande envoyée
+                                    </span>
+
+                                    <!-- REQUEST_RECEIVED: link to requests tab -->
+                                    <a th:if="${rs != null and rs.name() == 'REQUEST_RECEIVED'}"
+                                       href="javascript:void(0)" onclick="switchTab('requests')"
+                                       class="btn btn-outline-success btn-sm">
+                                        <i class="bi bi-inbox"></i> Vous a envoyé une demande
+                                    </a>
+
+                                    <!-- FRIENDS: show friendship badge -->
+                                    <span th:if="${rs != null and rs.name() == 'FRIENDS'}" class="badge bg-success">
+                                        <i class="bi bi-check-circle"></i> Ami
+                                    </span>
+
+                                    <!-- REJECTED: can resend -->
+                                    <form th:if="${rs != null and rs.name() == 'REJECTED'}" th:action="@{/friends/send}" method="post">
+                                        <input type="hidden" name="recipientId" th:value="${a.id}"/>
+                                        <button type="submit" class="btn btn-outline-warning btn-sm">
+                                            <i class="bi bi-arrow-repeat"></i> Renvoyer une demande
+                                        </button>
+                                    </form>
+
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- ==================== Tab 5: Liste noire (Blocked users) ==================== -->
+            <div class="tab-pane fade" id="tab-blocked" role="tabpanel" aria-labelledby="blocked-tab">
+                <div th:if="${#lists.isEmpty(blockedUsers)}" class="text-center py-5">
+                    <i class="bi bi-shield-check display-1 text-muted"></i>
+                    <p class="text-muted mt-3 fs-5">Votre liste noire est vide.</p>
+                    <p class="text-muted small">Bloquez un utilisateur pour l'empêcher de vous envoyer des demandes d'ami.</p>
+                </div>
+
+                <div th:if="${!#lists.isEmpty(blockedUsers)}" class="row g-3">
+                    <div class="col-12" th:each="blocked : ${blockedUsers}">
+                        <div class="card shadow-sm border-danger">
+                            <div class="card-body d-flex justify-content-between align-items-center flex-wrap gap-2">
+                                <div class="d-flex align-items-center gap-3">
+                                    <i class="bi bi-person-circle display-5 text-danger"></i>
+                                    <div>
+                                        <span class="fw-semibold fs-5"
+                                              th:text="${blocked.recipient.username}">Username</span>
+                                        <br>
+                                        <small class="text-muted">
+                                            <i class="bi bi-slash-circle"></i> Bloqué le
+                                            <span th:text="${#temporals.format(blocked.createdAt, 'dd/MM/yyyy HH:mm')}">Date</span>
+                                        </small>
+                                    </div>
+                                </div>
+                                <div class="d-flex gap-2">
+                                    <!-- Unblock button -->
+                                    <form th:action="@{/friends/unblock/{id}(id=${blocked.recipient.id})}" method="post">
+                                        <button type="submit" class="btn btn-outline-success btn-sm"
+                                                onclick="return confirm('Débloquer cet utilisateur ?')">
+                                            <i class="bi bi-unlock"></i> Débloquer
+                                        </button>
+                                    </form>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -292,7 +370,8 @@
                 'friends': 'friends-tab',
                 'requests': 'requests-tab',
                 'sent': 'sent-tab',
-                'add': 'add-tab'
+                'add': 'add-tab',
+                'blocked': 'blocked-tab'
             };
             var tabId = tabMap[tab] || 'friends-tab';
             var tabEl = document.getElementById(tabId);
@@ -308,7 +387,8 @@
                 'friends': 'friends-tab',
                 'requests': 'requests-tab',
                 'sent': 'sent-tab',
-                'add': 'add-tab'
+                'add': 'add-tab',
+                'blocked': 'blocked-tab'
             };
             var tabId = tabMap[tabName];
             if (tabId) {

--- a/src/main/resources/templates/athlete/friend/profile.html
+++ b/src/main/resources/templates/athlete/friend/profile.html
@@ -89,33 +89,121 @@
                         <p class="text-muted mt-2 mb-0">C'est votre propre profil.</p>
                     </div>
 
-                    <!-- NONE: Not friends -->
+                    <!-- NONE: No relationship -->
                     <div th:if="${relationshipStatus == 'NONE'}">
                         <i class="bi bi-person-x display-4 text-secondary"></i>
                         <p class="text-muted mt-2 mb-3">Vous n'êtes pas encore amis.</p>
-                        <form th:action="@{/friends/send}" method="post">
-                            <input type="hidden" name="recipientId" th:value="${profileAthlete.id}"/>
-                            <button type="submit" class="btn btn-primary">
-                                <i class="bi bi-person-plus-fill"></i> Envoyer une demande d'ami
+                        <div class="d-flex justify-content-center gap-2">
+                            <form th:action="@{/friends/send}" method="post">
+                                <input type="hidden" name="recipientId" th:value="${profileAthlete.id}"/>
+                                <button type="submit" class="btn btn-primary">
+                                    <i class="bi bi-person-plus-fill"></i> Envoyer une demande d'ami
+                                </button>
+                            </form>
+                            <form th:action="@{/friends/block/{id}(id=${profileAthlete.id})}" method="post">
+                                <button type="submit" class="btn btn-outline-danger btn-sm"
+                                        onclick="return confirm('Bloquer cet utilisateur ?')">
+                                    <i class="bi bi-slash-circle"></i> Bloquer
+                                </button>
+                            </form>
+                        </div>
+                    </div>
+
+                    <!-- REQUEST_SENT: Current user sent a pending request -->
+                    <div th:if="${relationshipStatus == 'REQUEST_SENT'}">
+                        <i class="bi bi-hourglass-split display-4 text-warning"></i>
+                        <p class="text-warning mt-2 mb-1 fw-semibold">Demande envoyée</p>
+                        <p class="text-muted small mb-3">Votre demande d'ami est en attente de réponse.</p>
+                        <form th:action="@{/friends/block/{id}(id=${profileAthlete.id})}" method="post">
+                            <button type="submit" class="btn btn-outline-danger btn-sm"
+                                    onclick="return confirm('Bloquer cet utilisateur ?')">
+                                <i class="bi bi-slash-circle"></i> Bloquer
                             </button>
                         </form>
                     </div>
 
-                    <!-- PENDING: Request pending -->
-                    <div th:if="${relationshipStatus == 'PENDING'}">
-                        <i class="bi bi-hourglass-split display-4 text-warning"></i>
-                        <p class="text-warning mt-2 mb-1 fw-semibold">Demande en attente</p>
-                        <p class="text-muted small mb-0">Une demande d'ami est en cours de traitement.</p>
+                    <!-- REQUEST_RECEIVED: Current user received a pending request -->
+                    <div th:if="${relationshipStatus == 'REQUEST_RECEIVED'}">
+                        <i class="bi bi-inbox display-4 text-info"></i>
+                        <p class="text-info mt-2 mb-1 fw-semibold">Demande reçue</p>
+                        <p class="text-muted small mb-3">Cet utilisateur souhaite être votre ami.</p>
+                        <div class="d-flex justify-content-center gap-2" th:if="${friendship != null}">
+                            <form th:action="@{/friends/accept/{id}(id=${friendship.id})}" method="post">
+                                <button type="submit" class="btn btn-success btn-sm">
+                                    <i class="bi bi-check-lg"></i> Accepter
+                                </button>
+                            </form>
+                            <form th:action="@{/friends/reject/{id}(id=${friendship.id})}" method="post">
+                                <button type="submit" class="btn btn-outline-danger btn-sm">
+                                    <i class="bi bi-x-lg"></i> Refuser
+                                </button>
+                            </form>
+                        </div>
                     </div>
 
-                    <!-- ACCEPTED: Are friends -->
-                    <div th:if="${relationshipStatus == 'ACCEPTED'}">
+                    <!-- FRIENDS: Already friends -->
+                    <div th:if="${relationshipStatus == 'FRIENDS'}">
                         <i class="bi bi-heart-fill display-4 text-success"></i>
                         <p class="text-success mt-2 mb-3 fw-semibold">Vous êtes amis ✅</p>
-                        <button type="button" class="btn btn-outline-danger"
-                                data-bs-toggle="modal" data-bs-target="#removeModal">
-                            <i class="bi bi-person-dash"></i> Supprimer cet ami
-                        </button>
+                        <div class="d-flex justify-content-center gap-2">
+                            <button type="button" class="btn btn-outline-danger"
+                                    data-bs-toggle="modal" data-bs-target="#removeModal">
+                                <i class="bi bi-person-dash"></i> Supprimer cet ami
+                            </button>
+                            <form th:action="@{/friends/block/{id}(id=${profileAthlete.id})}" method="post">
+                                <button type="submit" class="btn btn-outline-danger btn-sm"
+                                        onclick="return confirm('Bloquer cet utilisateur ? Cela supprimera votre amitié.')">
+                                    <i class="bi bi-slash-circle"></i> Bloquer
+                                </button>
+                            </form>
+                        </div>
+                    </div>
+
+                    <!-- REJECTED: Request was rejected -->
+                    <div th:if="${relationshipStatus == 'REJECTED'}">
+                        <i class="bi bi-x-circle display-4 text-secondary"></i>
+                        <p class="text-secondary mt-2 mb-3 fw-semibold">Demande refusée</p>
+                        <div class="d-flex justify-content-center gap-2">
+                            <form th:action="@{/friends/send}" method="post">
+                                <input type="hidden" name="recipientId" th:value="${profileAthlete.id}"/>
+                                <button type="submit" class="btn btn-outline-warning btn-sm">
+                                    <i class="bi bi-arrow-repeat"></i> Renvoyer une demande
+                                </button>
+                            </form>
+                            <form th:action="@{/friends/block/{id}(id=${profileAthlete.id})}" method="post">
+                                <button type="submit" class="btn btn-outline-danger btn-sm"
+                                        onclick="return confirm('Bloquer cet utilisateur ?')">
+                                    <i class="bi bi-slash-circle"></i> Bloquer
+                                </button>
+                            </form>
+                        </div>
+                    </div>
+
+                    <!-- BLOCKED_BY_ME: Current user blocked the target -->
+                    <div th:if="${relationshipStatus == 'BLOCKED_BY_ME'}">
+                        <i class="bi bi-slash-circle-fill display-4 text-danger"></i>
+                        <p class="text-danger mt-2 mb-1 fw-semibold">Utilisateur bloqué</p>
+                        <p class="text-muted small mb-3">Vous avez bloqué cet utilisateur. Il ne peut pas vous envoyer de demande d'ami.</p>
+                        <form th:action="@{/friends/unblock/{id}(id=${profileAthlete.id})}" method="post">
+                            <button type="submit" class="btn btn-outline-success btn-sm"
+                                    onclick="return confirm('Débloquer cet utilisateur ?')">
+                                <i class="bi bi-unlock"></i> Débloquer
+                            </button>
+                        </form>
+                    </div>
+
+                    <!-- BLOCKED_ME: Target blocked the current user -->
+                    <div th:if="${relationshipStatus == 'BLOCKED_ME'}">
+                        <i class="bi bi-shield-exclamation display-4 text-danger"></i>
+                        <p class="text-danger mt-2 mb-0 fw-semibold">Action impossible</p>
+                        <p class="text-muted small mb-0">Vous ne pouvez pas interagir avec cet utilisateur.</p>
+                    </div>
+
+                    <!-- MUTUALLY_BLOCKED -->
+                    <div th:if="${relationshipStatus == 'MUTUALLY_BLOCKED'}">
+                        <i class="bi bi-shield-fill-exclamation display-4 text-danger"></i>
+                        <p class="text-danger mt-2 mb-1 fw-semibold">Bloquage mutuel</p>
+                        <p class="text-muted small mb-0">Vous et cet utilisateur vous êtes mutuellement bloqués.</p>
                     </div>
 
                 </div>

--- a/src/test/java/fr/utc/miage/sporttrack/controller/FriendshipControllerTest.java
+++ b/src/test/java/fr/utc/miage/sporttrack/controller/FriendshipControllerTest.java
@@ -1,7 +1,10 @@
 package fr.utc.miage.sporttrack.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -9,7 +12,9 @@ import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.AfterEach;
@@ -26,12 +31,12 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.ui.Model;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import fr.utc.miage.sporttrack.dto.RelationshipStatusDTO;
 import fr.utc.miage.sporttrack.entity.enumeration.FriendshipStatus;
 import fr.utc.miage.sporttrack.entity.user.Athlete;
 import fr.utc.miage.sporttrack.entity.user.communication.Friendship;
 import fr.utc.miage.sporttrack.repository.user.AthleteRepository;
 import fr.utc.miage.sporttrack.repository.user.communication.FriendshipRepository;
-import fr.utc.miage.sporttrack.service.user.AthleteService;
 import fr.utc.miage.sporttrack.service.user.communication.FriendshipService;
 import jakarta.servlet.http.HttpSession;
 
@@ -50,9 +55,6 @@ class FriendshipControllerTest {
 
     @Mock
     private AthleteRepository athleteRepository;
-
-    @Mock
-    private AthleteService athleteService;
 
     @Mock
     private Model model;
@@ -87,7 +89,6 @@ class FriendshipControllerTest {
     @Test
     void friendsPage_shouldRedirectToLogin_whenNotAuthenticated() {
         when(session.getAttribute("athlete")).thenReturn(null);
-        // SecurityContextHolder has no authentication by default after clear
 
         String result = controller.friendsPage(session, null, null, model);
 
@@ -100,7 +101,9 @@ class FriendshipControllerTest {
         when(friendshipService.getFriendsOfAthlete(1)).thenReturn(List.of(otherAthlete));
         when(friendshipService.getPendingRequestsForAthlete(1)).thenReturn(Collections.emptyList());
         when(friendshipService.getSentPendingRequests(1)).thenReturn(Collections.emptyList());
-        when(athleteService.getAllAthletes()).thenReturn(new ArrayList<>(List.of(currentAthlete, otherAthlete)));
+        when(friendshipService.getBlockedUsers(1)).thenReturn(Collections.emptyList());
+        when(friendshipService.searchVisibleAthletes(eq(1), eq(null))).thenReturn(List.of(otherAthlete));
+        when(friendshipService.getRelationshipStatus(1, 2)).thenReturn(RelationshipStatusDTO.NONE);
 
         String result = controller.friendsPage(session, null, null, model);
 
@@ -108,6 +111,7 @@ class FriendshipControllerTest {
         verify(model).addAttribute("friends", List.of(otherAthlete));
         verify(model).addAttribute("requests", Collections.emptyList());
         verify(model).addAttribute("sentRequests", Collections.emptyList());
+        verify(model).addAttribute("blockedUsers", Collections.emptyList());
         verify(model).addAttribute("activeTab", "friends");
         verify(model).addAttribute("currentAthlete", currentAthlete);
     }
@@ -125,7 +129,8 @@ class FriendshipControllerTest {
         when(friendshipService.getFriendsOfAthlete(1)).thenReturn(Collections.emptyList());
         when(friendshipService.getPendingRequestsForAthlete(1)).thenReturn(Collections.emptyList());
         when(friendshipService.getSentPendingRequests(1)).thenReturn(Collections.emptyList());
-        when(athleteService.getAllAthletes()).thenReturn(new ArrayList<>(List.of(currentAthlete)));
+        when(friendshipService.getBlockedUsers(1)).thenReturn(Collections.emptyList());
+        when(friendshipService.searchVisibleAthletes(eq(1), any())).thenReturn(Collections.emptyList());
 
         String result = controller.friendsPage(session, null, null, model);
 
@@ -139,7 +144,9 @@ class FriendshipControllerTest {
         when(friendshipService.getFriendsOfAthlete(1)).thenReturn(Collections.emptyList());
         when(friendshipService.getPendingRequestsForAthlete(1)).thenReturn(Collections.emptyList());
         when(friendshipService.getSentPendingRequests(1)).thenReturn(Collections.emptyList());
-        when(athleteService.searchAthletesByName("other")).thenReturn(new ArrayList<>(List.of(otherAthlete)));
+        when(friendshipService.getBlockedUsers(1)).thenReturn(Collections.emptyList());
+        when(friendshipService.searchVisibleAthletes(1, "other")).thenReturn(List.of(otherAthlete));
+        when(friendshipService.getRelationshipStatus(1, 2)).thenReturn(RelationshipStatusDTO.NONE);
 
         String result = controller.friendsPage(session, "other", null, model);
 
@@ -154,7 +161,8 @@ class FriendshipControllerTest {
         when(friendshipService.getFriendsOfAthlete(1)).thenReturn(Collections.emptyList());
         when(friendshipService.getPendingRequestsForAthlete(1)).thenReturn(Collections.emptyList());
         when(friendshipService.getSentPendingRequests(1)).thenReturn(Collections.emptyList());
-        when(athleteService.getAllAthletes()).thenReturn(new ArrayList<>());
+        when(friendshipService.getBlockedUsers(1)).thenReturn(Collections.emptyList());
+        when(friendshipService.searchVisibleAthletes(eq(1), any())).thenReturn(Collections.emptyList());
 
         String result = controller.friendsPage(session, null, "requests", model);
 
@@ -168,7 +176,8 @@ class FriendshipControllerTest {
         when(friendshipService.getFriendsOfAthlete(1)).thenReturn(Collections.emptyList());
         when(friendshipService.getPendingRequestsForAthlete(1)).thenReturn(Collections.emptyList());
         when(friendshipService.getSentPendingRequests(1)).thenReturn(Collections.emptyList());
-        when(athleteService.getAllAthletes()).thenReturn(new ArrayList<>());
+        when(friendshipService.getBlockedUsers(1)).thenReturn(Collections.emptyList());
+        when(friendshipService.searchVisibleAthletes(eq(1), any())).thenReturn(Collections.emptyList());
 
         String result = controller.friendsPage(session, null, null, model);
 
@@ -177,37 +186,34 @@ class FriendshipControllerTest {
     }
 
     @Test
-    void friendsPage_shouldRemoveCurrentUserFromAthleteList() {
+    void friendsPage_shouldNotAddQueryAttribute_whenQueryIsEmpty() {
         when(session.getAttribute("athlete")).thenReturn(currentAthlete);
         when(friendshipService.getFriendsOfAthlete(1)).thenReturn(Collections.emptyList());
         when(friendshipService.getPendingRequestsForAthlete(1)).thenReturn(Collections.emptyList());
         when(friendshipService.getSentPendingRequests(1)).thenReturn(Collections.emptyList());
-        // Return a mutable list containing the current user
-        when(athleteService.getAllAthletes()).thenReturn(new ArrayList<>(List.of(currentAthlete, otherAthlete, thirdAthlete)));
-
-        controller.friendsPage(session, null, null, model);
-
-        // Verify the athletes attribute does not contain the current user
-        verify(model).addAttribute(eq("athletes"), argThat(list -> {
-            @SuppressWarnings("unchecked")
-            List<Athlete> athletes = (List<Athlete>) list;
-            return athletes.stream().noneMatch(a -> a.getId().equals(currentAthlete.getId()))
-                    && athletes.size() == 2;
-        }));
-    }
-
-    @Test
-    void friendsPage_shouldNotSearch_whenQueryIsEmpty() {
-        when(session.getAttribute("athlete")).thenReturn(currentAthlete);
-        when(friendshipService.getFriendsOfAthlete(1)).thenReturn(Collections.emptyList());
-        when(friendshipService.getPendingRequestsForAthlete(1)).thenReturn(Collections.emptyList());
-        when(friendshipService.getSentPendingRequests(1)).thenReturn(Collections.emptyList());
-        when(athleteService.getAllAthletes()).thenReturn(new ArrayList<>());
+        when(friendshipService.getBlockedUsers(1)).thenReturn(Collections.emptyList());
+        when(friendshipService.searchVisibleAthletes(eq(1), eq(""))).thenReturn(Collections.emptyList());
 
         controller.friendsPage(session, "", null, model);
 
-        verify(athleteService, never()).searchAthletesByName(anyString());
-        verify(athleteService).getAllAthletes();
+        verify(model, never()).addAttribute(eq("query"), anyString());
+    }
+
+    @Test
+    void friendsPage_shouldComputeRelationshipStatuses() {
+        when(session.getAttribute("athlete")).thenReturn(currentAthlete);
+        when(friendshipService.getFriendsOfAthlete(1)).thenReturn(Collections.emptyList());
+        when(friendshipService.getPendingRequestsForAthlete(1)).thenReturn(Collections.emptyList());
+        when(friendshipService.getSentPendingRequests(1)).thenReturn(Collections.emptyList());
+        when(friendshipService.getBlockedUsers(1)).thenReturn(Collections.emptyList());
+        when(friendshipService.searchVisibleAthletes(eq(1), any())).thenReturn(List.of(otherAthlete));
+        when(friendshipService.getRelationshipStatus(1, 2)).thenReturn(RelationshipStatusDTO.FRIENDS);
+
+        controller.friendsPage(session, null, null, model);
+
+        Map<Integer, RelationshipStatusDTO> expectedMap = new HashMap<>();
+        expectedMap.put(2, RelationshipStatusDTO.FRIENDS);
+        verify(model).addAttribute("relationshipStatuses", expectedMap);
     }
 
     // ======================== friendProfile tests ========================
@@ -235,6 +241,8 @@ class FriendshipControllerTest {
     void friendProfile_shouldReturnSELF_whenViewingOwnProfile() {
         when(session.getAttribute("athlete")).thenReturn(currentAthlete);
         when(athleteRepository.findById(1)).thenReturn(Optional.of(currentAthlete));
+        when(friendshipService.getRelationshipStatus(1, 1)).thenReturn(RelationshipStatusDTO.SELF);
+        when(friendshipRepository.findBetweenAthletes(currentAthlete, currentAthlete)).thenReturn(Optional.empty());
 
         String result = controller.friendProfile(1, session, model);
 
@@ -244,9 +252,26 @@ class FriendshipControllerTest {
     }
 
     @Test
-    void friendProfile_shouldReturnNONE_whenNoFriendshipExists() {
+    void friendProfile_shouldReturnFRIENDS_whenFriends() {
         when(session.getAttribute("athlete")).thenReturn(currentAthlete);
         when(athleteRepository.findById(2)).thenReturn(Optional.of(otherAthlete));
+        when(friendshipService.getRelationshipStatus(1, 2)).thenReturn(RelationshipStatusDTO.FRIENDS);
+
+        Friendship friendship = createFriendship(10, currentAthlete, otherAthlete, FriendshipStatus.ACCEPTED);
+        when(friendshipRepository.findBetweenAthletes(currentAthlete, otherAthlete)).thenReturn(Optional.of(friendship));
+
+        String result = controller.friendProfile(2, session, model);
+
+        assertEquals("athlete/friend/profile", result);
+        verify(model).addAttribute("relationshipStatus", "FRIENDS");
+        verify(model).addAttribute("friendship", friendship);
+    }
+
+    @Test
+    void friendProfile_shouldReturnNONE_whenNoFriendship() {
+        when(session.getAttribute("athlete")).thenReturn(currentAthlete);
+        when(athleteRepository.findById(2)).thenReturn(Optional.of(otherAthlete));
+        when(friendshipService.getRelationshipStatus(1, 2)).thenReturn(RelationshipStatusDTO.NONE);
         when(friendshipRepository.findBetweenAthletes(currentAthlete, otherAthlete)).thenReturn(Optional.empty());
 
         String result = controller.friendProfile(2, session, model);
@@ -257,24 +282,10 @@ class FriendshipControllerTest {
     }
 
     @Test
-    void friendProfile_shouldReturnACCEPTED_whenFriends() {
+    void friendProfile_shouldReturnREQUEST_SENT_whenRequestSent() {
         when(session.getAttribute("athlete")).thenReturn(currentAthlete);
         when(athleteRepository.findById(2)).thenReturn(Optional.of(otherAthlete));
-
-        Friendship friendship = createFriendship(10, currentAthlete, otherAthlete, FriendshipStatus.ACCEPTED);
-        when(friendshipRepository.findBetweenAthletes(currentAthlete, otherAthlete)).thenReturn(Optional.of(friendship));
-
-        String result = controller.friendProfile(2, session, model);
-
-        assertEquals("athlete/friend/profile", result);
-        verify(model).addAttribute("relationshipStatus", "ACCEPTED");
-        verify(model).addAttribute("friendship", friendship);
-    }
-
-    @Test
-    void friendProfile_shouldReturnPENDING_whenRequestPending() {
-        when(session.getAttribute("athlete")).thenReturn(currentAthlete);
-        when(athleteRepository.findById(2)).thenReturn(Optional.of(otherAthlete));
+        when(friendshipService.getRelationshipStatus(1, 2)).thenReturn(RelationshipStatusDTO.REQUEST_SENT);
 
         Friendship friendship = createFriendship(11, currentAthlete, otherAthlete, FriendshipStatus.PENDING);
         when(friendshipRepository.findBetweenAthletes(currentAthlete, otherAthlete)).thenReturn(Optional.of(friendship));
@@ -282,21 +293,22 @@ class FriendshipControllerTest {
         String result = controller.friendProfile(2, session, model);
 
         assertEquals("athlete/friend/profile", result);
-        verify(model).addAttribute("relationshipStatus", "PENDING");
+        verify(model).addAttribute("relationshipStatus", "REQUEST_SENT");
     }
 
     @Test
-    void friendProfile_shouldReturnNONE_whenFriendshipRejected() {
+    void friendProfile_shouldReturnBLOCKED_BY_ME_whenBlocked() {
         when(session.getAttribute("athlete")).thenReturn(currentAthlete);
         when(athleteRepository.findById(2)).thenReturn(Optional.of(otherAthlete));
+        when(friendshipService.getRelationshipStatus(1, 2)).thenReturn(RelationshipStatusDTO.BLOCKED_BY_ME);
 
-        Friendship friendship = createFriendship(12, currentAthlete, otherAthlete, FriendshipStatus.REJECTED);
+        Friendship friendship = createFriendship(12, currentAthlete, otherAthlete, FriendshipStatus.BLOCKED);
         when(friendshipRepository.findBetweenAthletes(currentAthlete, otherAthlete)).thenReturn(Optional.of(friendship));
 
         String result = controller.friendProfile(2, session, model);
 
         assertEquals("athlete/friend/profile", result);
-        verify(model).addAttribute("relationshipStatus", "NONE");
+        verify(model).addAttribute("relationshipStatus", "BLOCKED_BY_ME");
     }
 
     // ======================== sendFriendRequest tests ========================
@@ -334,15 +346,15 @@ class FriendshipControllerTest {
     }
 
     @Test
-    void sendFriendRequest_shouldRedirectWithError_whenSelfRequest() {
+    void sendFriendRequest_shouldRedirectWithError_whenBlockedException() {
         when(session.getAttribute("athlete")).thenReturn(currentAthlete);
-        doThrow(new IllegalArgumentException("You cannot send a friend request to yourself"))
-                .when(friendshipService).sendFriendRequest(1, 1);
+        doThrow(new IllegalStateException("Cannot send friend request to this user."))
+                .when(friendshipService).sendFriendRequest(1, 2);
 
-        String result = controller.sendFriendRequest(session, 1, redirectAttributes);
+        String result = controller.sendFriendRequest(session, 2, redirectAttributes);
 
         assertEquals("redirect:/friends?tab=add", result);
-        verify(redirectAttributes).addFlashAttribute("error", "You cannot send a friend request to yourself");
+        verify(redirectAttributes).addFlashAttribute("error", "Cannot send friend request to this user.");
     }
 
     // ======================== acceptFriendRequest tests ========================
@@ -377,18 +389,6 @@ class FriendshipControllerTest {
 
         assertEquals("redirect:/friends?tab=requests", result);
         verify(redirectAttributes).addFlashAttribute("error", "Only the recipient can accept a friend request");
-    }
-
-    @Test
-    void acceptFriendRequest_shouldRedirectWithError_whenNotPending() {
-        when(session.getAttribute("athlete")).thenReturn(currentAthlete);
-        doThrow(new IllegalStateException("Only pending friend requests can be accepted"))
-                .when(friendshipService).acceptFriendRequest(10, 1);
-
-        String result = controller.acceptFriendRequest(10, session, redirectAttributes);
-
-        assertEquals("redirect:/friends?tab=requests", result);
-        verify(redirectAttributes).addFlashAttribute("error", "Only pending friend requests can be accepted");
     }
 
     // ======================== rejectFriendRequest tests ========================
@@ -459,16 +459,96 @@ class FriendshipControllerTest {
         verify(redirectAttributes).addFlashAttribute("error", "Friendship does not exist");
     }
 
+    // ======================== blockUser tests ========================
+
     @Test
-    void removeFriend_shouldRedirectWithError_whenNotAccepted() {
+    void blockUser_shouldRedirectToLogin_whenNotAuthenticated() {
+        when(session.getAttribute("athlete")).thenReturn(null);
+
+        String result = controller.blockUser(2, session, redirectAttributes);
+
+        assertEquals("redirect:/login", result);
+    }
+
+    @Test
+    void blockUser_shouldRedirectWithSuccess_whenBlocked() {
         when(session.getAttribute("athlete")).thenReturn(currentAthlete);
-        doThrow(new IllegalStateException("Only accepted friendships can be removed"))
-                .when(friendshipService).removeFriend(1, 2);
 
-        String result = controller.removeFriend(2, session, redirectAttributes);
+        String result = controller.blockUser(2, session, redirectAttributes);
 
-        assertEquals("redirect:/friends?tab=friends", result);
-        verify(redirectAttributes).addFlashAttribute("error", "Only accepted friendships can be removed");
+        assertEquals("redirect:/friends?tab=blocked", result);
+        verify(friendshipService).blockUser(1, 2);
+        verify(redirectAttributes).addFlashAttribute("success", "Utilisateur bloqué avec succès.");
+    }
+
+    @Test
+    void blockUser_shouldRedirectWithError_whenExceptionThrown() {
+        when(session.getAttribute("athlete")).thenReturn(currentAthlete);
+        doThrow(new IllegalArgumentException("You cannot block yourself"))
+                .when(friendshipService).blockUser(1, 1);
+
+        String result = controller.blockUser(1, session, redirectAttributes);
+
+        assertEquals("redirect:/friends?tab=blocked", result);
+        verify(redirectAttributes).addFlashAttribute("error", "You cannot block yourself");
+    }
+
+    @Test
+    void blockUser_shouldRedirectWithError_whenAlreadyBlocked() {
+        when(session.getAttribute("athlete")).thenReturn(currentAthlete);
+        doThrow(new IllegalStateException("You have already blocked this user"))
+                .when(friendshipService).blockUser(1, 2);
+
+        String result = controller.blockUser(2, session, redirectAttributes);
+
+        assertEquals("redirect:/friends?tab=blocked", result);
+        verify(redirectAttributes).addFlashAttribute("error", "You have already blocked this user");
+    }
+
+    // ======================== unblockUser tests ========================
+
+    @Test
+    void unblockUser_shouldRedirectToLogin_whenNotAuthenticated() {
+        when(session.getAttribute("athlete")).thenReturn(null);
+
+        String result = controller.unblockUser(2, session, redirectAttributes);
+
+        assertEquals("redirect:/login", result);
+    }
+
+    @Test
+    void unblockUser_shouldRedirectWithSuccess_whenUnblocked() {
+        when(session.getAttribute("athlete")).thenReturn(currentAthlete);
+
+        String result = controller.unblockUser(2, session, redirectAttributes);
+
+        assertEquals("redirect:/friends?tab=blocked", result);
+        verify(friendshipService).unblockUser(1, 2);
+        verify(redirectAttributes).addFlashAttribute("success", "Utilisateur débloqué avec succès.");
+    }
+
+    @Test
+    void unblockUser_shouldRedirectWithError_whenExceptionThrown() {
+        when(session.getAttribute("athlete")).thenReturn(currentAthlete);
+        doThrow(new IllegalStateException("This user is not blocked"))
+                .when(friendshipService).unblockUser(1, 2);
+
+        String result = controller.unblockUser(2, session, redirectAttributes);
+
+        assertEquals("redirect:/friends?tab=blocked", result);
+        verify(redirectAttributes).addFlashAttribute("error", "This user is not blocked");
+    }
+
+    @Test
+    void unblockUser_shouldRedirectWithError_whenNotTheBlocker() {
+        when(session.getAttribute("athlete")).thenReturn(currentAthlete);
+        doThrow(new IllegalStateException("You did not block this user, so you cannot unblock them"))
+                .when(friendshipService).unblockUser(1, 2);
+
+        String result = controller.unblockUser(2, session, redirectAttributes);
+
+        assertEquals("redirect:/friends?tab=blocked", result);
+        verify(redirectAttributes).addFlashAttribute("error", "You did not block this user, so you cannot unblock them");
     }
 
     // ======================== getAuthenticatedAthlete (via public methods) ========================
@@ -538,7 +618,8 @@ class FriendshipControllerTest {
         when(friendshipService.getFriendsOfAthlete(1)).thenReturn(Collections.emptyList());
         when(friendshipService.getPendingRequestsForAthlete(1)).thenReturn(Collections.emptyList());
         when(friendshipService.getSentPendingRequests(1)).thenReturn(Collections.emptyList());
-        when(athleteService.getAllAthletes()).thenReturn(new ArrayList<>());
+        when(friendshipService.getBlockedUsers(1)).thenReturn(Collections.emptyList());
+        when(friendshipService.searchVisibleAthletes(eq(1), any())).thenReturn(Collections.emptyList());
 
         String result = controller.friendsPage(session, null, null, model);
 
@@ -552,12 +633,12 @@ class FriendshipControllerTest {
         when(friendshipService.getFriendsOfAthlete(1)).thenReturn(Collections.emptyList());
         when(friendshipService.getPendingRequestsForAthlete(1)).thenReturn(Collections.emptyList());
         when(friendshipService.getSentPendingRequests(1)).thenReturn(Collections.emptyList());
-        when(athleteService.getAllAthletes()).thenReturn(new ArrayList<>());
+        when(friendshipService.getBlockedUsers(1)).thenReturn(Collections.emptyList());
+        when(friendshipService.searchVisibleAthletes(eq(1), any())).thenReturn(Collections.emptyList());
 
         String result = controller.friendsPage(session, null, null, model);
 
         assertEquals("athlete/friend/friends", result);
-        // Should NOT query the repository since session already has the athlete
         verify(athleteRepository, never()).findByEmail(anyString());
     }
 

--- a/src/test/java/fr/utc/miage/sporttrack/entity/User/Communication/FriendshipTest.java
+++ b/src/test/java/fr/utc/miage/sporttrack/entity/User/Communication/FriendshipTest.java
@@ -54,6 +54,30 @@ class FriendshipTest {
         assertNotNull(f.getCreatedAt());
     }
 
+    @Test
+    void shouldCreateFriendshipWithThreeArgConstructor() {
+        Athlete initiator = createAthlete(1);
+        Athlete recipient = createAthlete(2);
+
+        Friendship f = new Friendship(initiator, recipient, FriendshipStatus.BLOCKED);
+
+        assertNull(f.getId());
+        assertEquals(initiator, f.getInitiator());
+        assertEquals(recipient, f.getRecipient());
+        assertEquals(FriendshipStatus.BLOCKED, f.getStatus());
+        assertNotNull(f.getCreatedAt());
+    }
+
+    @Test
+    void shouldCreateFriendshipWithThreeArgConstructorAccepted() {
+        Athlete initiator = createAthlete(1);
+        Athlete recipient = createAthlete(2);
+
+        Friendship f = new Friendship(initiator, recipient, FriendshipStatus.ACCEPTED);
+
+        assertEquals(FriendshipStatus.ACCEPTED, f.getStatus());
+    }
+
     // ==================== Getters and Setters ====================
 
     @Test

--- a/src/test/java/fr/utc/miage/sporttrack/service/user/communication/FriendshipServiceTest.java
+++ b/src/test/java/fr/utc/miage/sporttrack/service/user/communication/FriendshipServiceTest.java
@@ -1,5 +1,6 @@
 package fr.utc.miage.sporttrack.service.user.communication;
 
+import fr.utc.miage.sporttrack.dto.RelationshipStatusDTO;
 import fr.utc.miage.sporttrack.entity.enumeration.FriendshipStatus;
 import fr.utc.miage.sporttrack.entity.user.Athlete;
 import fr.utc.miage.sporttrack.entity.user.communication.Friendship;
@@ -11,11 +12,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -461,5 +464,549 @@ class FriendshipServiceTest {
         List<Friendship> result = service.getSentPendingRequests(USER_ID_1);
 
         assertTrue(result.isEmpty());
+    }
+
+    // ==================== sendFriendRequest - block checks ====================
+
+    @Test
+    void sendFriendRequest_shouldThrowWhenInitiatorBlockedRecipient() {
+        Athlete initiator = createAthlete(USER_ID_1);
+        Athlete recipient = createAthlete(USER_ID_2);
+
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.of(initiator));
+        when(athleteRepository.findById(USER_ID_2)).thenReturn(Optional.of(recipient));
+        when(friendshipRepository.existsBlock(initiator, recipient)).thenReturn(true);
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> service.sendFriendRequest(USER_ID_1, USER_ID_2));
+        assertEquals("You have blocked this user. Unblock them first.", ex.getMessage());
+    }
+
+    @Test
+    void sendFriendRequest_shouldThrowWhenRecipientBlockedInitiator() {
+        Athlete initiator = createAthlete(USER_ID_1);
+        Athlete recipient = createAthlete(USER_ID_2);
+
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.of(initiator));
+        when(athleteRepository.findById(USER_ID_2)).thenReturn(Optional.of(recipient));
+        when(friendshipRepository.existsBlock(initiator, recipient)).thenReturn(false);
+        when(friendshipRepository.existsBlock(recipient, initiator)).thenReturn(true);
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> service.sendFriendRequest(USER_ID_1, USER_ID_2));
+        assertEquals("Cannot send friend request to this user.", ex.getMessage());
+    }
+
+    @Test
+    void sendFriendRequest_shouldThrowWhenExistingBlockRelationship() {
+        Athlete initiator = createAthlete(USER_ID_1);
+        Athlete recipient = createAthlete(USER_ID_2);
+        Friendship existing = createFriendship(FRIENDSHIP_ID, initiator, recipient, FriendshipStatus.BLOCKED);
+
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.of(initiator));
+        when(athleteRepository.findById(USER_ID_2)).thenReturn(Optional.of(recipient));
+        when(friendshipRepository.existsBlock(initiator, recipient)).thenReturn(false);
+        when(friendshipRepository.existsBlock(recipient, initiator)).thenReturn(false);
+        when(friendshipRepository.findBetweenAthletes(initiator, recipient)).thenReturn(Optional.of(existing));
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> service.sendFriendRequest(USER_ID_1, USER_ID_2));
+        assertEquals("A block relationship exists between you and this user", ex.getMessage());
+    }
+
+    // ==================== 8. blockUser ====================
+
+    @Test
+    void blockUser_shouldThrowWhenBlockingSelf() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> service.blockUser(USER_ID_1, USER_ID_1));
+        assertEquals("You cannot block yourself", ex.getMessage());
+    }
+
+    @Test
+    void blockUser_shouldThrowWhenBlockerNotFound() {
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.empty());
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> service.blockUser(USER_ID_1, USER_ID_2));
+        assertEquals("Blocker not found", ex.getMessage());
+    }
+
+    @Test
+    void blockUser_shouldThrowWhenBlockedNotFound() {
+        Athlete blocker = createAthlete(USER_ID_1);
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.of(blocker));
+        when(athleteRepository.findById(USER_ID_2)).thenReturn(Optional.empty());
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> service.blockUser(USER_ID_1, USER_ID_2));
+        assertEquals("User to block not found", ex.getMessage());
+    }
+
+    @Test
+    void blockUser_shouldThrowWhenAlreadyBlockedBySameUser() {
+        Athlete blocker = createAthlete(USER_ID_1);
+        Athlete blocked = createAthlete(USER_ID_2);
+        Friendship existing = createFriendship(FRIENDSHIP_ID, blocker, blocked, FriendshipStatus.BLOCKED);
+
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.of(blocker));
+        when(athleteRepository.findById(USER_ID_2)).thenReturn(Optional.of(blocked));
+        when(friendshipRepository.findBetweenAthletes(blocker, blocked)).thenReturn(Optional.of(existing));
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> service.blockUser(USER_ID_1, USER_ID_2));
+        assertEquals("You have already blocked this user", ex.getMessage());
+    }
+
+    @Test
+    void blockUser_shouldReverseBlockWhenOtherUserBlockedUs() {
+        Athlete blocker = createAthlete(USER_ID_1);
+        Athlete blocked = createAthlete(USER_ID_2);
+        // blocked previously blocked blocker (initiator=blocked, recipient=blocker)
+        Friendship existing = createFriendship(FRIENDSHIP_ID, blocked, blocker, FriendshipStatus.BLOCKED);
+
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.of(blocker));
+        when(athleteRepository.findById(USER_ID_2)).thenReturn(Optional.of(blocked));
+        when(friendshipRepository.findBetweenAthletes(blocker, blocked)).thenReturn(Optional.of(existing));
+
+        service.blockUser(USER_ID_1, USER_ID_2);
+
+        assertEquals(blocker, existing.getInitiator());
+        assertEquals(blocked, existing.getRecipient());
+        assertEquals(FriendshipStatus.BLOCKED, existing.getStatus());
+        verify(friendshipRepository).save(existing);
+    }
+
+    @Test
+    void blockUser_shouldConvertAcceptedToBlocked() {
+        Athlete blocker = createAthlete(USER_ID_1);
+        Athlete blocked = createAthlete(USER_ID_2);
+        Friendship existing = createFriendship(FRIENDSHIP_ID, blocker, blocked, FriendshipStatus.ACCEPTED);
+
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.of(blocker));
+        when(athleteRepository.findById(USER_ID_2)).thenReturn(Optional.of(blocked));
+        when(friendshipRepository.findBetweenAthletes(blocker, blocked)).thenReturn(Optional.of(existing));
+
+        service.blockUser(USER_ID_1, USER_ID_2);
+
+        assertEquals(FriendshipStatus.BLOCKED, existing.getStatus());
+        assertEquals(blocker, existing.getInitiator());
+        assertEquals(blocked, existing.getRecipient());
+        verify(friendshipRepository).save(existing);
+    }
+
+    @Test
+    void blockUser_shouldConvertPendingToBlocked() {
+        Athlete blocker = createAthlete(USER_ID_1);
+        Athlete blocked = createAthlete(USER_ID_2);
+        Friendship existing = createFriendship(FRIENDSHIP_ID, blocked, blocker, FriendshipStatus.PENDING);
+
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.of(blocker));
+        when(athleteRepository.findById(USER_ID_2)).thenReturn(Optional.of(blocked));
+        when(friendshipRepository.findBetweenAthletes(blocker, blocked)).thenReturn(Optional.of(existing));
+
+        service.blockUser(USER_ID_1, USER_ID_2);
+
+        assertEquals(FriendshipStatus.BLOCKED, existing.getStatus());
+        assertEquals(blocker, existing.getInitiator());
+        assertEquals(blocked, existing.getRecipient());
+        verify(friendshipRepository).save(existing);
+    }
+
+    @Test
+    void blockUser_shouldConvertRejectedToBlocked() {
+        Athlete blocker = createAthlete(USER_ID_1);
+        Athlete blocked = createAthlete(USER_ID_2);
+        Friendship existing = createFriendship(FRIENDSHIP_ID, blocker, blocked, FriendshipStatus.REJECTED);
+
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.of(blocker));
+        when(athleteRepository.findById(USER_ID_2)).thenReturn(Optional.of(blocked));
+        when(friendshipRepository.findBetweenAthletes(blocker, blocked)).thenReturn(Optional.of(existing));
+
+        service.blockUser(USER_ID_1, USER_ID_2);
+
+        assertEquals(FriendshipStatus.BLOCKED, existing.getStatus());
+        verify(friendshipRepository).save(existing);
+    }
+
+    @Test
+    void blockUser_shouldCreateNewBlockedWhenNoExisting() {
+        Athlete blocker = createAthlete(USER_ID_1);
+        Athlete blocked = createAthlete(USER_ID_2);
+
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.of(blocker));
+        when(athleteRepository.findById(USER_ID_2)).thenReturn(Optional.of(blocked));
+        when(friendshipRepository.findBetweenAthletes(blocker, blocked)).thenReturn(Optional.empty());
+
+        service.blockUser(USER_ID_1, USER_ID_2);
+
+        verify(friendshipRepository).save(any(Friendship.class));
+    }
+
+    // ==================== 9. unblockUser ====================
+
+    @Test
+    void unblockUser_shouldThrowWhenUnblockingSelf() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> service.unblockUser(USER_ID_1, USER_ID_1));
+        assertEquals("Invalid operation", ex.getMessage());
+    }
+
+    @Test
+    void unblockUser_shouldThrowWhenBlockerNotFound() {
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.empty());
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> service.unblockUser(USER_ID_1, USER_ID_2));
+        assertEquals("Blocker not found", ex.getMessage());
+    }
+
+    @Test
+    void unblockUser_shouldThrowWhenNoRelationshipExists() {
+        Athlete blocker = createAthlete(USER_ID_1);
+        Athlete blocked = createAthlete(USER_ID_2);
+
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.of(blocker));
+        when(athleteRepository.findById(USER_ID_2)).thenReturn(Optional.of(blocked));
+        when(friendshipRepository.findBetweenAthletes(blocker, blocked)).thenReturn(Optional.empty());
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> service.unblockUser(USER_ID_1, USER_ID_2));
+        assertEquals("No relationship exists between these users", ex.getMessage());
+    }
+
+    @Test
+    void unblockUser_shouldThrowWhenNotBlocked() {
+        Athlete blocker = createAthlete(USER_ID_1);
+        Athlete blocked = createAthlete(USER_ID_2);
+        Friendship existing = createFriendship(FRIENDSHIP_ID, blocker, blocked, FriendshipStatus.ACCEPTED);
+
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.of(blocker));
+        when(athleteRepository.findById(USER_ID_2)).thenReturn(Optional.of(blocked));
+        when(friendshipRepository.findBetweenAthletes(blocker, blocked)).thenReturn(Optional.of(existing));
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> service.unblockUser(USER_ID_1, USER_ID_2));
+        assertEquals("This user is not blocked", ex.getMessage());
+    }
+
+    @Test
+    void unblockUser_shouldThrowWhenNotTheBlocker() {
+        Athlete blocker = createAthlete(USER_ID_1);
+        Athlete blocked = createAthlete(USER_ID_2);
+        // blocked blocked blocker (initiator=blocked)
+        Friendship existing = createFriendship(FRIENDSHIP_ID, blocked, blocker, FriendshipStatus.BLOCKED);
+
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.of(blocker));
+        when(athleteRepository.findById(USER_ID_2)).thenReturn(Optional.of(blocked));
+        when(friendshipRepository.findBetweenAthletes(blocker, blocked)).thenReturn(Optional.of(existing));
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> service.unblockUser(USER_ID_1, USER_ID_2));
+        assertEquals("You did not block this user, so you cannot unblock them", ex.getMessage());
+    }
+
+    @Test
+    void unblockUser_shouldSucceedWhenBlockerUnblocks() {
+        Athlete blocker = createAthlete(USER_ID_1);
+        Athlete blocked = createAthlete(USER_ID_2);
+        Friendship existing = createFriendship(FRIENDSHIP_ID, blocker, blocked, FriendshipStatus.BLOCKED);
+
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.of(blocker));
+        when(athleteRepository.findById(USER_ID_2)).thenReturn(Optional.of(blocked));
+        when(friendshipRepository.findBetweenAthletes(blocker, blocked)).thenReturn(Optional.of(existing));
+
+        service.unblockUser(USER_ID_1, USER_ID_2);
+
+        verify(friendshipRepository).delete(existing);
+    }
+
+    // ==================== 10. getBlockedUsers ====================
+
+    @Test
+    void getBlockedUsers_shouldThrowWhenAthleteNotFound() {
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.empty());
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> service.getBlockedUsers(USER_ID_1));
+        assertEquals("Athlete not found", ex.getMessage());
+    }
+
+    @Test
+    void getBlockedUsers_shouldReturnBlockedUsers() {
+        Athlete athlete = createAthlete(USER_ID_1);
+        Athlete blocked = createAthlete(USER_ID_2);
+        Friendship f = createFriendship(FRIENDSHIP_ID, athlete, blocked, FriendshipStatus.BLOCKED);
+
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.of(athlete));
+        when(friendshipRepository.findByInitiatorAndStatus(athlete, FriendshipStatus.BLOCKED))
+                .thenReturn(List.of(f));
+
+        List<Friendship> result = service.getBlockedUsers(USER_ID_1);
+
+        assertEquals(1, result.size());
+        assertEquals(f, result.get(0));
+    }
+
+    @Test
+    void getBlockedUsers_shouldReturnEmptyList() {
+        Athlete athlete = createAthlete(USER_ID_1);
+
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.of(athlete));
+        when(friendshipRepository.findByInitiatorAndStatus(athlete, FriendshipStatus.BLOCKED))
+                .thenReturn(List.of());
+
+        List<Friendship> result = service.getBlockedUsers(USER_ID_1);
+
+        assertTrue(result.isEmpty());
+    }
+
+    // ==================== 11. getRelationshipStatus ====================
+
+    @Test
+    void getRelationshipStatus_shouldReturnSELF() {
+        RelationshipStatusDTO result = service.getRelationshipStatus(USER_ID_1, USER_ID_1);
+        assertEquals(RelationshipStatusDTO.SELF, result);
+    }
+
+    @Test
+    void getRelationshipStatus_shouldThrowWhenViewerNotFound() {
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.empty());
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.getRelationshipStatus(USER_ID_1, USER_ID_2));
+    }
+
+    @Test
+    void getRelationshipStatus_shouldReturnMutuallyBlocked() {
+        Athlete viewer = createAthlete(USER_ID_1);
+        Athlete target = createAthlete(USER_ID_2);
+
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.of(viewer));
+        when(athleteRepository.findById(USER_ID_2)).thenReturn(Optional.of(target));
+        when(friendshipRepository.existsBlock(viewer, target)).thenReturn(true);
+        when(friendshipRepository.existsBlock(target, viewer)).thenReturn(true);
+
+        RelationshipStatusDTO result = service.getRelationshipStatus(USER_ID_1, USER_ID_2);
+        assertEquals(RelationshipStatusDTO.MUTUALLY_BLOCKED, result);
+    }
+
+    @Test
+    void getRelationshipStatus_shouldReturnBlockedByMe() {
+        Athlete viewer = createAthlete(USER_ID_1);
+        Athlete target = createAthlete(USER_ID_2);
+
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.of(viewer));
+        when(athleteRepository.findById(USER_ID_2)).thenReturn(Optional.of(target));
+        when(friendshipRepository.existsBlock(viewer, target)).thenReturn(true);
+        when(friendshipRepository.existsBlock(target, viewer)).thenReturn(false);
+
+        RelationshipStatusDTO result = service.getRelationshipStatus(USER_ID_1, USER_ID_2);
+        assertEquals(RelationshipStatusDTO.BLOCKED_BY_ME, result);
+    }
+
+    @Test
+    void getRelationshipStatus_shouldReturnBlockedMe() {
+        Athlete viewer = createAthlete(USER_ID_1);
+        Athlete target = createAthlete(USER_ID_2);
+
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.of(viewer));
+        when(athleteRepository.findById(USER_ID_2)).thenReturn(Optional.of(target));
+        when(friendshipRepository.existsBlock(viewer, target)).thenReturn(false);
+        when(friendshipRepository.existsBlock(target, viewer)).thenReturn(true);
+
+        RelationshipStatusDTO result = service.getRelationshipStatus(USER_ID_1, USER_ID_2);
+        assertEquals(RelationshipStatusDTO.BLOCKED_ME, result);
+    }
+
+    @Test
+    void getRelationshipStatus_shouldReturnNoneWhenNoFriendship() {
+        Athlete viewer = createAthlete(USER_ID_1);
+        Athlete target = createAthlete(USER_ID_2);
+
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.of(viewer));
+        when(athleteRepository.findById(USER_ID_2)).thenReturn(Optional.of(target));
+        when(friendshipRepository.existsBlock(viewer, target)).thenReturn(false);
+        when(friendshipRepository.existsBlock(target, viewer)).thenReturn(false);
+        when(friendshipRepository.findBetweenAthletes(viewer, target)).thenReturn(Optional.empty());
+
+        RelationshipStatusDTO result = service.getRelationshipStatus(USER_ID_1, USER_ID_2);
+        assertEquals(RelationshipStatusDTO.NONE, result);
+    }
+
+    @Test
+    void getRelationshipStatus_shouldReturnFriends() {
+        Athlete viewer = createAthlete(USER_ID_1);
+        Athlete target = createAthlete(USER_ID_2);
+        Friendship f = createFriendship(FRIENDSHIP_ID, viewer, target, FriendshipStatus.ACCEPTED);
+
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.of(viewer));
+        when(athleteRepository.findById(USER_ID_2)).thenReturn(Optional.of(target));
+        when(friendshipRepository.existsBlock(viewer, target)).thenReturn(false);
+        when(friendshipRepository.existsBlock(target, viewer)).thenReturn(false);
+        when(friendshipRepository.findBetweenAthletes(viewer, target)).thenReturn(Optional.of(f));
+
+        RelationshipStatusDTO result = service.getRelationshipStatus(USER_ID_1, USER_ID_2);
+        assertEquals(RelationshipStatusDTO.FRIENDS, result);
+    }
+
+    @Test
+    void getRelationshipStatus_shouldReturnRequestSent() {
+        Athlete viewer = createAthlete(USER_ID_1);
+        Athlete target = createAthlete(USER_ID_2);
+        Friendship f = createFriendship(FRIENDSHIP_ID, viewer, target, FriendshipStatus.PENDING);
+
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.of(viewer));
+        when(athleteRepository.findById(USER_ID_2)).thenReturn(Optional.of(target));
+        when(friendshipRepository.existsBlock(viewer, target)).thenReturn(false);
+        when(friendshipRepository.existsBlock(target, viewer)).thenReturn(false);
+        when(friendshipRepository.findBetweenAthletes(viewer, target)).thenReturn(Optional.of(f));
+
+        RelationshipStatusDTO result = service.getRelationshipStatus(USER_ID_1, USER_ID_2);
+        assertEquals(RelationshipStatusDTO.REQUEST_SENT, result);
+    }
+
+    @Test
+    void getRelationshipStatus_shouldReturnRequestReceived() {
+        Athlete viewer = createAthlete(USER_ID_1);
+        Athlete target = createAthlete(USER_ID_2);
+        Friendship f = createFriendship(FRIENDSHIP_ID, target, viewer, FriendshipStatus.PENDING);
+
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.of(viewer));
+        when(athleteRepository.findById(USER_ID_2)).thenReturn(Optional.of(target));
+        when(friendshipRepository.existsBlock(viewer, target)).thenReturn(false);
+        when(friendshipRepository.existsBlock(target, viewer)).thenReturn(false);
+        when(friendshipRepository.findBetweenAthletes(viewer, target)).thenReturn(Optional.of(f));
+
+        RelationshipStatusDTO result = service.getRelationshipStatus(USER_ID_1, USER_ID_2);
+        assertEquals(RelationshipStatusDTO.REQUEST_RECEIVED, result);
+    }
+
+    @Test
+    void getRelationshipStatus_shouldReturnRejected() {
+        Athlete viewer = createAthlete(USER_ID_1);
+        Athlete target = createAthlete(USER_ID_2);
+        Friendship f = createFriendship(FRIENDSHIP_ID, viewer, target, FriendshipStatus.REJECTED);
+
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.of(viewer));
+        when(athleteRepository.findById(USER_ID_2)).thenReturn(Optional.of(target));
+        when(friendshipRepository.existsBlock(viewer, target)).thenReturn(false);
+        when(friendshipRepository.existsBlock(target, viewer)).thenReturn(false);
+        when(friendshipRepository.findBetweenAthletes(viewer, target)).thenReturn(Optional.of(f));
+
+        RelationshipStatusDTO result = service.getRelationshipStatus(USER_ID_1, USER_ID_2);
+        assertEquals(RelationshipStatusDTO.REJECTED, result);
+    }
+
+    @Test
+    void getRelationshipStatus_shouldReturnBlockedByMeFromFriendship() {
+        Athlete viewer = createAthlete(USER_ID_1);
+        Athlete target = createAthlete(USER_ID_2);
+        // BLOCKED via friendship record but existsBlock returned false (edge case)
+        Friendship f = createFriendship(FRIENDSHIP_ID, viewer, target, FriendshipStatus.BLOCKED);
+
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.of(viewer));
+        when(athleteRepository.findById(USER_ID_2)).thenReturn(Optional.of(target));
+        when(friendshipRepository.existsBlock(viewer, target)).thenReturn(false);
+        when(friendshipRepository.existsBlock(target, viewer)).thenReturn(false);
+        when(friendshipRepository.findBetweenAthletes(viewer, target)).thenReturn(Optional.of(f));
+
+        RelationshipStatusDTO result = service.getRelationshipStatus(USER_ID_1, USER_ID_2);
+        assertEquals(RelationshipStatusDTO.BLOCKED_BY_ME, result);
+    }
+
+    @Test
+    void getRelationshipStatus_shouldReturnBlockedMeFromFriendship() {
+        Athlete viewer = createAthlete(USER_ID_1);
+        Athlete target = createAthlete(USER_ID_2);
+        Friendship f = createFriendship(FRIENDSHIP_ID, target, viewer, FriendshipStatus.BLOCKED);
+
+        when(athleteRepository.findById(USER_ID_1)).thenReturn(Optional.of(viewer));
+        when(athleteRepository.findById(USER_ID_2)).thenReturn(Optional.of(target));
+        when(friendshipRepository.existsBlock(viewer, target)).thenReturn(false);
+        when(friendshipRepository.existsBlock(target, viewer)).thenReturn(false);
+        when(friendshipRepository.findBetweenAthletes(viewer, target)).thenReturn(Optional.of(f));
+
+        RelationshipStatusDTO result = service.getRelationshipStatus(USER_ID_1, USER_ID_2);
+        assertEquals(RelationshipStatusDTO.BLOCKED_ME, result);
+    }
+
+    // ==================== 12. searchVisibleAthletes ====================
+
+    @Test
+    void searchVisibleAthletes_shouldFilterSelf() {
+        Athlete athlete = createAthlete(USER_ID_1);
+        Athlete other = createAthlete(USER_ID_2);
+
+        when(athleteRepository.findByUsernameContainingIgnoreCase("user")).thenReturn(List.of(athlete, other));
+        when(friendshipRepository.findBlockedUserIds(USER_ID_1)).thenReturn(List.of());
+        when(friendshipRepository.findBlockedByUserIds(USER_ID_1)).thenReturn(List.of());
+
+        List<Athlete> result = service.searchVisibleAthletes(USER_ID_1, "user");
+
+        assertEquals(1, result.size());
+        assertEquals(other, result.get(0));
+    }
+
+    @Test
+    void searchVisibleAthletes_shouldFilterBlockedByMe() {
+        Athlete athlete = createAthlete(USER_ID_1);
+        Athlete other = createAthlete(USER_ID_2);
+        Athlete blocked = createAthlete(USER_ID_3);
+
+        when(athleteRepository.findByUsernameContainingIgnoreCase("user")).thenReturn(List.of(other, blocked));
+        when(friendshipRepository.findBlockedUserIds(USER_ID_1)).thenReturn(List.of(USER_ID_3));
+        when(friendshipRepository.findBlockedByUserIds(USER_ID_1)).thenReturn(List.of());
+
+        List<Athlete> result = service.searchVisibleAthletes(USER_ID_1, "user");
+
+        assertEquals(1, result.size());
+        assertEquals(other, result.get(0));
+    }
+
+    @Test
+    void searchVisibleAthletes_shouldFilterBlockedMe() {
+        Athlete athlete = createAthlete(USER_ID_1);
+        Athlete other = createAthlete(USER_ID_2);
+        Athlete blocker = createAthlete(USER_ID_3);
+
+        when(athleteRepository.findByUsernameContainingIgnoreCase("user")).thenReturn(List.of(other, blocker));
+        when(friendshipRepository.findBlockedUserIds(USER_ID_1)).thenReturn(List.of());
+        when(friendshipRepository.findBlockedByUserIds(USER_ID_1)).thenReturn(List.of(USER_ID_3));
+
+        List<Athlete> result = service.searchVisibleAthletes(USER_ID_1, "user");
+
+        assertEquals(1, result.size());
+        assertEquals(other, result.get(0));
+    }
+
+    @Test
+    void searchVisibleAthletes_shouldReturnAllWhenNoKeyword() {
+        Athlete athlete = createAthlete(USER_ID_1);
+        Athlete other = createAthlete(USER_ID_2);
+
+        when(athleteRepository.findAll()).thenReturn(List.of(athlete, other));
+        when(friendshipRepository.findBlockedUserIds(USER_ID_1)).thenReturn(List.of());
+        when(friendshipRepository.findBlockedByUserIds(USER_ID_1)).thenReturn(List.of());
+
+        List<Athlete> result = service.searchVisibleAthletes(USER_ID_1, null);
+
+        assertEquals(1, result.size());
+        assertEquals(other, result.get(0));
+    }
+
+    @Test
+    void searchVisibleAthletes_shouldReturnAllWhenEmptyKeyword() {
+        Athlete athlete = createAthlete(USER_ID_1);
+        Athlete other = createAthlete(USER_ID_2);
+
+        when(athleteRepository.findAll()).thenReturn(List.of(athlete, other));
+        when(friendshipRepository.findBlockedUserIds(USER_ID_1)).thenReturn(List.of());
+        when(friendshipRepository.findBlockedByUserIds(USER_ID_1)).thenReturn(List.of());
+
+        List<Athlete> result = service.searchVisibleAthletes(USER_ID_1, "");
+
+        assertEquals(1, result.size());
+        assertEquals(other, result.get(0));
     }
 }


### PR DESCRIPTION
Update FriendshipController to support blocking/unblocking by adding a 5th tab for blocked users. Remove AthleteService dependency and delegate search to FriendshipService.searchVisibleAthletes. Introduce RelationshipStatusDTO to cleanly map and track relationship states between athletes. Improve search results handling by calculating relationship statuses for the view.

Implements US #24
Implements US #25

(Closes #65, Closes #66)